### PR TITLE
Be friendlier when CUDA isn't found

### DIFF
--- a/fahbench/GPUInfo.cpp
+++ b/fahbench/GPUInfo.cpp
@@ -101,7 +101,7 @@ vector<Device> GPUInfo::getCUDADevices() {
     cudaGetDeviceProperties_pt my_cuGetDeviceProperties;
 
     if ((cu_rt = loadCudaLibrary()) == nullptr)
-        throw std::runtime_error("CUDA ERROR: could not load cuda runtime");
+        throw std::runtime_error("I couldn't find the Cuda runtime. Disabling CUDA.");
     if ((my_cuGetDeviceCount = (cudaGetDeviceCount_pt) getProcAddress(cu_rt, "cudaGetDeviceCount")) == nullptr)
         throw std::runtime_error("CUDA ERROR: could not load cudaGetDeviceCount");
     if ((my_cuGetDeviceProperties = (cudaGetDeviceProperties_pt) getProcAddress(cu_rt, "cudaGetDeviceProperties")) == nullptr)


### PR DESCRIPTION
Instead of "CUDA ERROR", gently tell the user that cuda was not found.
