### PR TITLE
Fix warnings and provide initializer for Simulation

### DIFF
--- a/fahbench/Device.cpp
+++ b/fahbench/Device.cpp
@@ -2,9 +2,13 @@
 
 using std::string;
 
-Device::Device(const string & platform, const string & device, int device_id, int platform_id) :
-    _platform(platform), _device(device), _device_id(device_id), _platform_id(platform_id) {
-}
+Device::Device(const string & platform, const string & device, int device_id, int platform_id)
+    : _device(device)
+    , _platform(platform)
+    , _device_id(device_id)
+    , _platform_id(platform_id)
+
+{ }
 
 const string & Device::device() const {
     return _device;

--- a/fahbench/GPUInfo.cpp
+++ b/fahbench/GPUInfo.cpp
@@ -24,7 +24,7 @@ vector<Device> GPUInfo::getOpenCLDevices() {
         throw std::runtime_error("OpenCL Error: Cannot get platforms.");
 
     vector<Device> openCLdevices;
-    for (int j = 0; j < n_platforms; j++) {
+    for (cl_uint j = 0; j < n_platforms; j++) {
 
         // Get devices for each platform
         cl_device_id devices[MAXDEVICES];
@@ -39,7 +39,7 @@ vector<Device> GPUInfo::getOpenCLDevices() {
             throw std::runtime_error("OpenCL Error: Cannot get platform version.");
         string platform_version = plat_version_buffer;
 
-        for (int i = 0; i < n_devices; i++) {
+        for (cl_uint i = 0; i < n_devices; i++) {
             char buffer[10240];
             error = clGetDeviceInfo(devices[i], CL_DEVICE_NAME, sizeof(buffer), buffer, NULL);
             if (error)

--- a/fahbench/Simulation.cpp
+++ b/fahbench/Simulation.cpp
@@ -25,10 +25,17 @@ using std::map;
 
 static boost::format data_fmt("%1%/dhfr.%2%.%3%.xml");
 
-Simulation::Simulation() {
-    openmm_plugin_dir = fs::canonical(getExecutableDir() / fs::path("../lib/plugins"));
-    work_unit = nullptr;
-}
+Simulation::Simulation()
+    : work_unit(nullptr)
+    , platform("OpenCL")
+    , precision("single")
+    , deviceId(0)
+    , platformId(0)
+    , verifyAccuracy(true)
+    , nan_check_freq(0)
+    , openmm_plugin_dir(fs::canonical(getExecutableDir() / fs::path("../lib/plugins")))
+
+{ }
 
 
 map< string, string > Simulation::getPropertiesMap() const {
@@ -59,6 +66,12 @@ string Simulation::summary() const {
     ss << "Steps: " << work_unit->n_steps();
     if (work_unit->user_n_steps()) {
         ss << " (user specified)" << std::endl;
+    } else {
+        ss << std::endl;
+    }
+    ss << "Device ID " << deviceId << "; Platform " << platform;
+    if (platform == "OpenCL") {
+        ss << "; Platform ID " << platformId << std::endl;
     } else {
         ss << std::endl;
     }

--- a/fahbench/Simulation.h
+++ b/fahbench/Simulation.h
@@ -43,7 +43,6 @@ public:
     SimulationResult run(Updater & update) const;
 
 private:
-    fs::path openmm_data_dir;
     fs::path openmm_plugin_dir;
 
     template<class T>

--- a/fahbench/StateTests.cpp
+++ b/fahbench/StateTests.cpp
@@ -46,7 +46,6 @@ void StateTests::checkForNans(const State & state) {
 
 
 void StateTests::checkForDiscrepancies(const State & state) {
-    const vector<Vec3> & positions = state.getPositions();
     const vector<Vec3> & velocities = state.getVelocities();
     const vector<Vec3> & forces = state.getForces();
     Vec3 a, b, c;

--- a/fahbench/WorkUnit.cpp
+++ b/fahbench/WorkUnit.cpp
@@ -15,8 +15,9 @@ WorkUnit::WorkUnit(const fs::path & wu_path)
     : _system_fn(wu_path / "system.xml")
     , _integrator_fn(wu_path / "integrator.xml")
     , _state_fn(wu_path / "state.xml")
-    , _codename(wu_path.filename().string())
     , _user_n_steps(0)
+    , _codename(wu_path.filename().string())
+
 
 {
     auto meta_path = wu_path / "wu.json";
@@ -35,10 +36,11 @@ WorkUnit::WorkUnit(const string & system, const string & integrator, const strin
     : _system_fn(system)
     , _integrator_fn(integrator)
     , _state_fn(state)
+    , _n_steps(steps)
+    , _user_n_steps(0)
     , _codename("custom")
     , _fullname("Custom WU")
     , _description("User-specified xml files.")
-    , _n_steps(steps)
 
 { }
 

--- a/fahbench/cmd/cmd-main.cpp
+++ b/fahbench/cmd/cmd-main.cpp
@@ -146,11 +146,14 @@ int main(int argc, char ** argv) {
         return show_info_instead;
     }
 
+    simulation.verifyAccuracy = true; // default
+
     if (vm.count("disable-accuracy-check")) {
         simulation.verifyAccuracy = false;
     }
 
     if (vm.count("enable_accuracy-check")) {
+        // override
         simulation.verifyAccuracy = true;
     }
 

--- a/fahbench/gui/DeviceTableModel.cpp
+++ b/fahbench/gui/DeviceTableModel.cpp
@@ -39,7 +39,7 @@ QVariant DeviceTableModel::data(const QModelIndex & index, int role) const {
     if (!index.isValid())
         return QVariant();
 
-    if (index.row() >= _entries.size())
+    if (index.row() < 0 || ((unsigned)index.row() >= _entries.size()))
         return QVariant();
 
     if (role != Qt::DisplayRole)


### PR DESCRIPTION
fixes #35 by (1) making sure cmd-main initializes all the fields and (2) providing a sensible default constructor that initializes all the fields
