### PR TITLE
Make sure `dhfr` is the default workunit 

### DIFF
--- a/fahbench/CMakeLists.txt
+++ b/fahbench/CMakeLists.txt
@@ -51,7 +51,7 @@ else()
 endif()
 
 add_library(fahbench SHARED ${fahbench_sources})
-add_dependencies(fahbench boost)
+add_dependencies(fahbench boost workunits)
 set_target_properties(fahbench PROPERTIES INSTALL_RPATH "$ORIGIN")
 
 # Link

--- a/fahbench/gui/WorkUnitTableModel.cpp
+++ b/fahbench/gui/WorkUnitTableModel.cpp
@@ -1,11 +1,14 @@
-//
-// Created by harrigan on 12/16/15.
-//
-
+#include <algorithm>
 #include "WorkUnitTableModel.h"
+
+bool put_dhfr_first(const WorkUnit & a, const WorkUnit & b) {
+    return a.codename() == "dhfr";
+}
+
 
 WorkUnitTableModel::WorkUnitTableModel()
     : _entries(WorkUnit::available_wus()) {
+    std::sort(_entries.begin(), _entries.end(), put_dhfr_first);
 
 }
 


### PR DESCRIPTION
WUs are loaded from the filesystem, so the order is pretty arbitrary. If
there's a WU named "dhfr", put it first so that we have reasonably
consistent defaults.

Fixes #56 
